### PR TITLE
Rename vscode-forge-tools to Autodesk Forge Tools

### DIFF
--- a/docs/setup/_shared/vscode.md
+++ b/docs/setup/_shared/vscode.md
@@ -6,6 +6,6 @@ Simply install the latest stable build for your platform.
 :::tip
 We've built an extension for Visual Studio Code that provides insight into
 some of the APS services and data directly from the editor:
-[vscode-forge-tools](https://marketplace.visualstudio.com/items?itemName=petrbroz.vscode-forge-tools).
+[Autodesk Forge Tools](https://marketplace.visualstudio.com/items?itemName=petrbroz.vscode-forge-tools).
 This could be useful when debugging your own APS applications.
 :::


### PR DESCRIPTION
Searching for vscode-forge-tools in VS Code extensions doesn't return any results. The extension is called Autodesk Forge Tools so updated the text to reflect that, and verified that searching for Autodesk Forge Tools does list the correct extension in VS Code.