### PR TITLE
Remove file size limit on file upload to .NET Simple Viewer.

### DIFF
--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -56,8 +56,7 @@ public class ModelsController : ControllerBase
         public IFormFile File { get; set; }
     }
 
-    [HttpPost()]
-    [RequestSizeLimit(500_000_000)]
+    [HttpPost(), DisableRequestSizeLimit]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())

--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -57,6 +57,7 @@ public class ModelsController : ControllerBase
     }
 
     [HttpPost()]
+    [RequestSizeLimit(500_000_000)]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())


### PR DESCRIPTION
Documentation change to match the pull request (https://github.com/autodesk-platform-services/aps-simple-viewer-dotnet/pull/3) to the .NET Simple Viewer tutorial which fixes the issue (https://github.com/autodesk-platform-services/aps-simple-viewer-dotnet/issues/2).