### PR TITLE
Added viewer config with extensions to hubs browser tutorial

### DIFF
--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -56,8 +56,7 @@ public class ModelsController : ControllerBase
         public IFormFile File { get; set; }
     }
 
-    [HttpPost()]
-    [RequestSizeLimit(500_000_000)]
+    [HttpPost(), DisableRequestSizeLimit]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())

--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -57,6 +57,7 @@ public class ModelsController : ControllerBase
     }
 
     [HttpPost()]
+    [RequestSizeLimit(500_000_000)]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())

--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -56,7 +56,7 @@ public class ModelsController : ControllerBase
         public IFormFile File { get; set; }
     }
 
-    [HttpPost(), DisableRequestSizeLimit]
+    [HttpPost()]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())

--- a/docs/03-tutorials/02-hubs-browser/04-viewer.mdx
+++ b/docs/03-tutorials/02-hubs-browser/04-viewer.mdx
@@ -41,8 +41,11 @@ async function getAccessToken(callback) {
 
 export function initViewer(container) {
     return new Promise(function (resolve, reject) {
-        Autodesk.Viewing.Initializer({ getAccessToken }, async function () {
-            const viewer = new Autodesk.Viewing.GuiViewer3D(container);
+        Autodesk.Viewing.Initializer({ getAccessToken }, function () {
+            const config = {
+                extensions: ['Autodesk.DocumentBrowser']
+            };
+            const viewer = new Autodesk.Viewing.GuiViewer3D(container, config);
             viewer.start();
             viewer.setTheme('light-theme');
             resolve(viewer);


### PR DESCRIPTION
Added the "Autodesk.DocumentBrowser" extension to the viewer to match the aps-simple-viewer tutorial. During the bootcamp, how to add this was asked multiple times.

Reference the pull request to the sample repo:
https://github.com/autodesk-platform-services/aps-hubs-browser-dotnet/pull/1