### PR TITLE
Update endpoints.mdx

### DIFF
--- a/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
+++ b/docs/03-tutorials/01-simple-viewer/_shared/dotnet/data/endpoints.mdx
@@ -57,6 +57,7 @@ public class ModelsController : ControllerBase
     }
 
     [HttpPost()]
+    [RequestSizeLimit(100_000_000)]
     public async Task<BucketObject> UploadAndTranslateModel([FromForm] UploadModelForm form)
     {
         using (var stream = new MemoryStream())


### PR DESCRIPTION
Some of the example files that are linked to for a user to upload exceed 30,000,000 bytes, which is the default upload size limit in ASP.NET Core 6.  Adding this attribute makes it so all the example files that are linked to will load without erroring.